### PR TITLE
Added Infix to Postfix solution in C++

### DIFF
--- a/problems/stack/InfixToPostfix.cpp
+++ b/problems/stack/InfixToPostfix.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <stack>
+#include <string>
+using namespace std;
+
+// Function to check if a character is operator
+bool isOperator(char c) {
+    return (c == '+' || c == '-' || c == '*' || c == '/');
+}
+
+// Function to return precedence
+int precedence(char c) {
+    if (c == '*' || c == '/') return 2;
+    if (c == '+' || c == '-') return 1;
+    return 0;
+}
+
+// Convert infix to postfix
+string infixToPostfix(string infix) {
+    stack<char> s;
+    string postfix = "";
+
+    for (char c : infix) {
+        if (isalnum(c)) {  // Operand
+            postfix += c;
+        } else if (c == '(') {
+            s.push(c);
+        } else if (c == ')') {
+            while (!s.empty() && s.top() != '(') {
+                postfix += s.top();
+                s.pop();
+            }
+            if (!s.empty()) s.pop(); // pop '('
+        } else if (isOperator(c)) {
+            while (!s.empty() && precedence(s.top()) >= precedence(c)) {
+                postfix += s.top();
+                s.pop();
+            }
+            s.push(c);
+        }
+    }
+
+    while (!s.empty()) {
+        postfix += s.top();
+        s.pop();
+    }
+
+    return postfix;
+}
+
+int main() {
+    string infix;
+    cout << "Enter Infix Expression: ";
+    cin >> infix;
+
+    string postfix = infixToPostfix(infix);
+    cout << "Postfix Expression: " << postfix << endl;
+
+    return 0;
+}


### PR DESCRIPTION
Pull Request Title:

Add Infix to Postfix solution in C++

Description:

Added a C++ program to convert infix expressions to postfix using a stack.
Tested on an online compiler. Screenshot of the output is attached.


### **Description:**

This PR adds a C++ program to convert **infix expressions** to **postfix notation** using a stack.

**Features:**

* Handles `+`, `-`, `*`, `/` operators
* Supports parentheses `()`
* Converts expressions like `(A+B)*C` to `AB+C*`

**Testing:**
* Output screenshots are attached below

**Example Input/Output:**

| Input     | Output  |
| --------- | ------- |
| `A+B`     | `AB+`   |
| `A+B*C`   | `ABC*+` |
| `(A+B)*C` | `AB+C*` |



**Checklist:**

* [x] Added code to the correct folder: `problems/stack/`
* [x] Tested online
* [x] Added description and example

---


OUTPUT:
<img width="527" height="167" alt="image" src="https://github.com/user-attachments/assets/ccc281d7-a1bc-4098-8dd4-6de2090e813a" />
